### PR TITLE
Small refactor of template handling

### DIFF
--- a/microplan-init.js
+++ b/microplan-init.js
@@ -37,47 +37,43 @@ function _parseInputFromUser (callback) {
     .option('-t, --template <location>', 'specify input template location', templateFileLocation.yaml)
     .parse(process.argv)
 
-  var initArgs = program.args
-
-  if (initArgs.length < 1) {
-    callback('Filename required. Please specify a valid' + suppFileExtns.join('/') + 'template location as argument.', null)
+  if (program.args.length < 1) {
+    callback('Please specify a valid filename for plan output.', null)
   }
+
+  var destFilePath = program.args[0]
 
   if (utils.fileExists(program.template) === false) {
-    callback('Please specify a valid' + suppFileExtns.join('/') + 'template file location.', null)
+    callback('Please specify a valid template file location.', null)
   }
 
-  let fileExt = path.extname(program.template)
+  var fileExt = path.extname(program.template)
 
   if (suppFileExtns.indexOf(fileExt) === -1) {
-    callback('File extension not supported. Please use supported file extensions: ' + suppFileExtns.join(', '), null)
+    callback('Template extension not supported. Please use supported file extensions: ' + suppFileExtns.join(', '), null)
   } else {
-    callback(null, program.template, initArgs)
+    callback(null, program.template, destFilePath)
   }
 }
 
-function _getOptsFromUser (templateFilePath, initArgs, callback) {
-  var destFilePath = initArgs[0]
+function _getOptsFromUser (templateFilePath, destFilePath, callback) {
   if (utils.fileExists(destFilePath)) {
     rl.question('File already exists. Do you want to overwrite this file? [N/y]', function (answer) {
       if (userOptsYes.indexOf(answer) === -1) {
         callback('Not overwriting the file: ' + destFilePath + '. Create plan file with new name and try again.', null)
       }
-      callback(null, templateFilePath, initArgs)
+      callback(null, templateFilePath, destFilePath)
     })
   } else {
-    callback(null, templateFilePath, initArgs)
+    callback(null, templateFilePath, destFilePath)
   }
 }
 
-function _copyTemplateFile (templateFilePath, initArgs, callback) {
-  var destFilePath = initArgs[0]
-  initArgs.forEach(function (initArg) {
-    try {
-      fs.copySync(templateFilePath, destFilePath)
-    } catch (err) {
-      callback(err, 'Error copying to the file: ' + destFilePath)
-    }
-    callback(null, 'Plan file copied successfully: ' + destFilePath)
-  })
+function _copyTemplateFile (templateFilePath, destFilePath, callback) {
+  try {
+    fs.copySync(templateFilePath, destFilePath)
+  } catch (err) {
+    callback(err, 'Error copying to the file: ' + destFilePath)
+  }
+  callback(null, 'Plan file copied successfully: ' + destFilePath)
 }


### PR DESCRIPTION
Summary of changes:
- Refactored template handling a little bit to make it more readable and provide correct error messages (previously lack of plan output filename provided error about template file)
- Changed callback chain to pass only destination filename, not whole args list, as only it was used
- Changed one `let` to `var` (I'm all for ES6, but let's keep it consistent 😁)