### PR TITLE
Allow creating plans in custom directory

### DIFF
--- a/microplan-init.js
+++ b/microplan-init.js
@@ -35,12 +35,12 @@ async.waterfall([
 function _parseInputFromUser (callback) {
   program
     .option('-t, --template <location>', 'specify input template location', templateFileLocation.yaml)
+    .option('-d, --directory <location>', 'specify plan output directory')
     .parse(process.argv)
 
   if (program.args.length < 1) {
     callback('Please specify a valid filename for plan output.', null)
   }
-
   var destFilePath = program.args[0]
 
   if (utils.fileExists(program.template) === false) {
@@ -51,9 +51,16 @@ function _parseInputFromUser (callback) {
 
   if (suppFileExtns.indexOf(fileExt) === -1) {
     callback('Template extension not supported. Please use supported file extensions: ' + suppFileExtns.join(', '), null)
-  } else {
-    callback(null, program.template, destFilePath)
   }
+
+  if (program.directory) {
+    if (utils.directoryExists(program.directory) === false) {
+      callback('Please provide a valid directory path', null)
+    }
+    destFilePath = path.join(program.directory, destFilePath)
+  }
+
+  callback(null, program.template, destFilePath)
 }
 
 function _getOptsFromUser (templateFilePath, destFilePath, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microplan",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Plan your project from command line",
   "main": "microplan.js",
   "scripts": {

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -22,8 +22,17 @@ function fileExists (filePath) {
   }
 }
 
+function directoryExists (dirPath) {
+  try {
+    return fs.statSync(dirPath).isDirectory()
+  } catch (err) {
+    return false
+  }
+}
+
 module.exports =
 {
   fileExists: fileExists,
+  directoryExists: directoryExists,
   parseSlug: parseSlug
 }


### PR DESCRIPTION
This PR adds `-d`/`--directory` optional flag to `init` command which when supplied with valid directory path will make `init` create plan inside it, instead of current directory. Resolves #89 